### PR TITLE
feat: implement league entity, routes, controllers and use cases (#10)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,8 @@
             "version": "1.0.0",
             "license": "ISC",
             "dependencies": {
-                "dotenv": "^17.3.1",
-                "express": "^5.2.1"
-            },
-            "devDependencies": {
-                "@types/express": "^5.0.6",
-                "@types/node": "^25.3.0",
                 "bcryptjs": "^3.0.3",
+                "dotenv": "^17.3.1",
                 "express": "^5.2.1",
                 "uuid": "^13.0.0"
             },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "homepage": "https://github.com/PannaMaster-Proyecto-Final-DAW/backend-futbol-app#readme",
     "dependencies": {
         "dotenv": "^17.3.1",
-        "express": "^5.2.1"
+        "express": "^5.2.1",
         "bcryptjs": "^3.0.3",
         "express": "^5.2.1",
         "uuid": "^13.0.0"

--- a/src/gameLogic/infrastructure/routes/user.routes.ts
+++ b/src/gameLogic/infrastructure/routes/user.routes.ts
@@ -35,10 +35,10 @@ const userController = new UserController(
 
 router.post('/', userController.create);
 router.get('/', userController.getAll);
-router.get('/search/id/:id', userController.getById);
-router.get('/search/username/:userName', userController.getByUserName);
-router.get('/search/email/:email', userController.getByEmail);
-router.get('/search/role/:role', userController.getByRole);
+router.get('/id/:id', userController.getById);
+router.get('/username/:userName', userController.getByUserName);
+router.get('/email/:email', userController.getByEmail);
+router.get('/role/:role', userController.getByRole);
 router.patch('/:id', userController.update);
 router.delete('/:id', userController.delete);
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,7 +6,7 @@ dotenv.config();
 // import { connectDB } from './infrastructure/config/postgres.config.js'; // TODO: Create database config
 
 const app = express();
-const PORT = process.env.PORT || 4000;
+const PORT = process.env.PORT;
 
 // Middlewares
 app.use(express.json());
@@ -25,7 +25,7 @@ app.use(express.json());
 import { countryRouter } from "./soccerData/infrastructure/routes/country.routes.js";
 import { leagueRouter } from "./soccerData/infrastructure/routes/league.routes.js";
 
-app.use("/countries", countryRouter);
+app.use("/api/countries", countryRouter);
 app.use("/api/leagues", leagueRouter);
 
 app.listen(PORT, async () => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -23,8 +23,10 @@ app.get('/', (req, res) => {
 app.use(express.json());
 
 import { countryRouter } from "./soccerData/infrastructure/routes/country.routes.js";
+import { leagueRouter } from "./soccerData/infrastructure/routes/league.routes.js";
 
 app.use("/countries", countryRouter);
+app.use("/api/leagues", leagueRouter);
 
 app.listen(PORT, async () => {
     // await connectDB(); // TODO: Uncomment when database config is ready

--- a/src/soccerData/application/use-cases/league/create.use-case.ts
+++ b/src/soccerData/application/use-cases/league/create.use-case.ts
@@ -1,0 +1,39 @@
+import { League, LeagueCategory } from "../../../domain/entities/league.entity.js";
+import { LeagueRepository } from "../../../domain/repositories/league.domain.repository.js";
+import { Country } from "../../../domain/entities/country.entity.js";
+
+// Port ID generation 
+export interface IdGenerator {
+    generateId(): string;
+}
+
+// Input for League creation
+export interface CreateLeagueInput {
+    name: string;
+    country: Country;
+    category: LeagueCategory;
+}
+
+// Use Case to create a new league
+export class CreateLeagueUseCase {
+    constructor(
+        private readonly leagueRepository: LeagueRepository,
+        private readonly idGenerator: IdGenerator
+    ) { }
+
+    /**
+     * Executes the creation of a league
+     * @param input - The input data for creating a league
+     * @returns The created league
+     */
+    async execute(input: CreateLeagueInput): Promise<League> {
+        // 1. Generates a unique ID 
+        const id = this.idGenerator.generateId();
+
+        // 2. Creates the league entity
+        const league = new League(id, input.name, input.country, input.category);
+
+        // 3. Saves the league using the repository
+        return this.leagueRepository.create(league);
+    }
+}

--- a/src/soccerData/application/use-cases/league/delete.use-case.ts
+++ b/src/soccerData/application/use-cases/league/delete.use-case.ts
@@ -1,0 +1,23 @@
+import { LeagueRepository } from "../../../domain/repositories/league.domain.repository.js";
+
+export interface DeleteLeagueInput {
+    id: string;
+}
+
+/**
+ * Use case to delete a league.
+ */
+export class DeleteLeagueUseCase {
+    constructor(
+        private readonly leagueRepository: LeagueRepository
+    ) { }
+
+    /**
+     * Executes the deletion of a league.
+     * @param input - The input data containing the league ID to delete.
+     * @returns A promise that resolves to true if deleted, false otherwise.
+     */
+    async execute(input: DeleteLeagueInput): Promise<boolean> {
+        return this.leagueRepository.delete(input.id);
+    }
+}

--- a/src/soccerData/application/use-cases/league/get-all.use-case.ts
+++ b/src/soccerData/application/use-cases/league/get-all.use-case.ts
@@ -1,0 +1,19 @@
+import { League } from "../../../domain/entities/league.entity.js";
+import { LeagueRepository } from "../../../domain/repositories/league.domain.repository.js";
+
+/**
+ * Use case to retrieve all leagues.
+ */
+export class GetAllLeagueUseCase {
+    constructor(
+        private readonly leagueRepository: LeagueRepository
+    ) { }
+
+    /**
+     * Executes the retrieval of all leagues.
+     * @returns A promise that resolves to an array of League entities.
+     */
+    async execute(): Promise<League[]> {
+        return this.leagueRepository.getAll();
+    }
+}

--- a/src/soccerData/application/use-cases/league/get-by-category.use-case.ts
+++ b/src/soccerData/application/use-cases/league/get-by-category.use-case.ts
@@ -1,0 +1,24 @@
+import { League, LeagueCategory } from "../../../domain/entities/league.entity.js";
+import { LeagueRepository } from "../../../domain/repositories/league.domain.repository.js";
+
+export interface GetLeagueByCategoryInput {
+    category: LeagueCategory;
+}
+
+/**
+ * Use case to retrieve leagues by category.
+ */
+export class GetLeagueByCategoryUseCase {
+    constructor(
+        private readonly leagueRepository: LeagueRepository
+    ) { }
+
+    /**
+     * Executes the retrieval of leagues by category.
+     * @param input - The input data containing the league category.
+     * @returns A promise that resolves to an array of League entities.
+     */
+    async execute(input: GetLeagueByCategoryInput): Promise<League[]> {
+        return this.leagueRepository.getByCategory(input.category);
+    }
+}

--- a/src/soccerData/application/use-cases/league/get-by-country.use-case.ts
+++ b/src/soccerData/application/use-cases/league/get-by-country.use-case.ts
@@ -1,0 +1,24 @@
+import { League } from "../../../domain/entities/league.entity.js";
+import { LeagueRepository } from "../../../domain/repositories/league.domain.repository.js";
+
+export interface GetLeagueByCountryInput {
+    countryId: string;
+}
+
+/**
+ * Use case to retrieve leagues by country ID.
+ */
+export class GetLeagueByCountryUseCase {
+    constructor(
+        private readonly leagueRepository: LeagueRepository
+    ) { }
+
+    /**
+     * Executes the retrieval of leagues by country ID.
+     * @param input - The input data containing the country ID.
+     * @returns A promise that resolves to an array of League entities.
+     */
+    async execute(input: GetLeagueByCountryInput): Promise<League[]> {
+        return this.leagueRepository.getByCountry(input.countryId);
+    }
+}

--- a/src/soccerData/application/use-cases/league/get-by-id.use-case.ts
+++ b/src/soccerData/application/use-cases/league/get-by-id.use-case.ts
@@ -1,0 +1,24 @@
+import { League } from "../../../domain/entities/league.entity.js";
+import { LeagueRepository } from "../../../domain/repositories/league.domain.repository.js";
+
+export interface GetLeagueByIdInput {
+    id: string;
+}
+
+/**
+ * Use case to retrieve a league by its ID.
+ */
+export class GetLeagueByIdUseCase {
+    constructor(
+        private readonly leagueRepository: LeagueRepository
+    ) { }
+
+    /**
+     * Executes the retrieval of a league by its ID.
+     * @param input - The input data containing the league ID.
+     * @returns A promise that resolves to the found League entity.
+     */
+    async execute(input: GetLeagueByIdInput): Promise<League | null> {
+        return this.leagueRepository.getById(input.id);
+    }
+}

--- a/src/soccerData/application/use-cases/league/get-by-name.use-case.ts
+++ b/src/soccerData/application/use-cases/league/get-by-name.use-case.ts
@@ -1,0 +1,24 @@
+import { League } from "../../../domain/entities/league.entity.js";
+import { LeagueRepository } from "../../../domain/repositories/league.domain.repository.js";
+
+export interface GetLeagueByNameInput {
+    name: string;
+}
+
+/**
+ * Use case to retrieve a league by its name.
+ */
+export class GetLeagueByNameUseCase {
+    constructor(
+        private readonly leagueRepository: LeagueRepository
+    ) { }
+
+    /**
+     * Executes the retrieval of a league by its name.
+     * @param input - The input data containing the league name.
+     * @returns A promise that resolves to the found League entity.
+     */
+    async execute(input: GetLeagueByNameInput): Promise<League | null> {
+        return this.leagueRepository.getByName(input.name);
+    }
+}

--- a/src/soccerData/application/use-cases/league/update.use-case.ts
+++ b/src/soccerData/application/use-cases/league/update.use-case.ts
@@ -1,0 +1,42 @@
+import { League, LeagueCategory } from "../../../domain/entities/league.entity.js";
+import { LeagueRepository } from "../../../domain/repositories/league.domain.repository.js";
+import { Country } from "../../../domain/entities/country.entity.js";
+
+// Input for League update
+export interface UpdateLeagueInput {
+    id: string;
+    name?: string;
+    country?: Country;
+    category?: LeagueCategory;
+}
+
+/**
+ * Use case to update an existing league.
+ */
+export class UpdateLeagueUseCase {
+    constructor(
+        private readonly leagueRepository: LeagueRepository
+    ) { }
+
+    /**
+     * Executes the update of a league.
+     * @param input - The data to update including the league ID.
+     * @returns A promise that resolves to the updated league or null if not found.
+     */
+    async execute(input: UpdateLeagueInput): Promise<League | null> {
+        // 1. Get existing league
+        const existingLeague = await this.leagueRepository.getById(input.id);
+        if (!existingLeague) return null;
+
+        // 2. Update fields
+        const updatedLeague = new League(
+            existingLeague.id,
+            input.name ?? existingLeague.name,
+            input.country ?? existingLeague.country,
+            input.category ?? existingLeague.category
+        );
+
+        // 3. Save changes
+        return this.leagueRepository.update(input.id, updatedLeague);
+    }
+}

--- a/src/soccerData/domain/repositories/league.domain.repository.ts
+++ b/src/soccerData/domain/repositories/league.domain.repository.ts
@@ -1,0 +1,15 @@
+import type { League, LeagueCategory } from "../entities/league.entity.js";
+
+export interface LeagueRepository {
+    // CRUD operations
+    create(league: League): Promise<League>;
+    update(id: string, league: League): Promise<League | null>;
+    delete(id: string): Promise<boolean>;
+
+    // Search methods
+    getAll(): Promise<League[]>;
+    getById(id: string): Promise<League | null>;
+    getByName(name: string): Promise<League | null>;
+    getByCountry(countryId: string): Promise<League[]>;
+    getByCategory(category: LeagueCategory): Promise<League[]>;
+}

--- a/src/soccerData/infrastructure/container.ts
+++ b/src/soccerData/infrastructure/container.ts
@@ -1,5 +1,6 @@
 // In-Memory Implementation
 import { InMemoryCountryRepository } from "./repositories/in-memory-country.js";
+import { InMemoryLeagueRepository } from "./repositories/in-memory-league.js";
 
 // Services
 import { UuidGenerator } from "./services/uuid-generator.js";
@@ -8,6 +9,7 @@ import { UuidGenerator } from "./services/uuid-generator.js";
 // Singleton instances
 // In-Memory Implementation
 export const countryRepository = new InMemoryCountryRepository();
+export const leagueRepository = new InMemoryLeagueRepository();
 
 // Services
 export const idGenerator = new UuidGenerator();

--- a/src/soccerData/infrastructure/controllers/league.controller.ts
+++ b/src/soccerData/infrastructure/controllers/league.controller.ts
@@ -1,0 +1,140 @@
+import type { Request, Response } from "express";
+import { CreateLeagueUseCase } from "../../application/use-cases/league/create.use-case.js";
+import { GetAllLeagueUseCase } from "../../application/use-cases/league/get-all.use-case.js";
+import { GetLeagueByIdUseCase } from "../../application/use-cases/league/get-by-id.use-case.js";
+import { GetLeagueByNameUseCase } from "../../application/use-cases/league/get-by-name.use-case.js";
+import { GetLeagueByCountryUseCase } from "../../application/use-cases/league/get-by-country.use-case.js";
+import { GetLeagueByCategoryUseCase } from "../../application/use-cases/league/get-by-category.use-case.js";
+import { UpdateLeagueUseCase } from "../../application/use-cases/league/update.use-case.js";
+import { DeleteLeagueUseCase } from "../../application/use-cases/league/delete.use-case.js";
+import { LeagueCategory } from "../../domain/entities/league.entity.js";
+
+export class LeagueController {
+    constructor(
+        private readonly createLeagueUseCase: CreateLeagueUseCase,
+        private readonly getAllLeagueUseCase: GetAllLeagueUseCase,
+        private readonly getLeagueByIdUseCase: GetLeagueByIdUseCase,
+        private readonly getLeagueByNameUseCase: GetLeagueByNameUseCase,
+        private readonly getLeagueByCountryUseCase: GetLeagueByCountryUseCase,
+        private readonly getLeagueByCategoryUseCase: GetLeagueByCategoryUseCase,
+        private readonly updateLeagueUseCase: UpdateLeagueUseCase,
+        private readonly deleteLeagueUseCase: DeleteLeagueUseCase
+    ) {
+        this.create = this.create.bind(this);
+        this.getAll = this.getAll.bind(this);
+        this.getById = this.getById.bind(this);
+        this.getByName = this.getByName.bind(this);
+        this.getByCountry = this.getByCountry.bind(this);
+        this.getByCategory = this.getByCategory.bind(this);
+        this.update = this.update.bind(this);
+        this.delete = this.delete.bind(this);
+    }
+
+    async create(req: Request, res: Response): Promise<void> {
+        try {
+            const { name, country, category } = req.body;
+            const league = await this.createLeagueUseCase.execute({ name, country, category });
+            res.status(201).json(league);
+        } catch (error: any) {
+            res.status(400).json({ error: error.message });
+        }
+    }
+
+    async getAll(_req: Request, res: Response): Promise<void> {
+        try {
+            const leagues = await this.getAllLeagueUseCase.execute();
+            res.status(200).json(leagues);
+        } catch (error: any) {
+            res.status(500).json({ error: error.message });
+        }
+    }
+
+    async getById(req: Request, res: Response): Promise<void> {
+        try {
+            const { id } = req.params;
+            if (!id || typeof id !== 'string') {
+                res.status(400).json({ error: 'Invalid ID' });
+                return;
+            }
+            const league = await this.getLeagueByIdUseCase.execute({ id });
+            res.status(200).json(league);
+        } catch (error: any) {
+            res.status(404).json({ error: error.message });
+        }
+    }
+
+    async getByName(req: Request, res: Response): Promise<void> {
+        try {
+            const { name } = req.params;
+            if (!name || typeof name !== 'string') {
+                res.status(400).json({ error: 'Invalid name' });
+                return;
+            }
+            const league = await this.getLeagueByNameUseCase.execute({ name });
+            res.status(200).json(league);
+        } catch (error: any) {
+            res.status(404).json({ error: error.message });
+        }
+    }
+
+    async getByCountry(req: Request, res: Response): Promise<void> {
+        try {
+            const { countryId } = req.params;
+            if (!countryId || typeof countryId !== 'string') {
+                res.status(400).json({ error: 'Invalid country ID' });
+                return;
+            }
+            const leagues = await this.getLeagueByCountryUseCase.execute({ countryId });
+            res.status(200).json(leagues);
+        } catch (error: any) {
+            res.status(400).json({ error: error.message });
+        }
+    }
+
+    async getByCategory(req: Request, res: Response): Promise<void> {
+        try {
+            const { category } = req.params;
+            if (!category || !Object.values(LeagueCategory).includes(category as LeagueCategory)) {
+                res.status(400).json({ error: 'Invalid category' });
+                return;
+            }
+            const leagues = await this.getLeagueByCategoryUseCase.execute({ category: category as LeagueCategory });
+            res.status(200).json(leagues);
+        } catch (error: any) {
+            res.status(400).json({ error: error.message });
+        }
+    }
+
+    async update(req: Request, res: Response): Promise<void> {
+        try {
+            const { id } = req.params;
+            const { name, country, category } = req.body;
+            if (!id || typeof id !== 'string') {
+                res.status(400).json({ error: 'Invalid ID' });
+                return;
+            }
+            const league = await this.updateLeagueUseCase.execute({ id, name, country, category });
+            res.status(200).json(league);
+        } catch (error: any) {
+            res.status(400).json({ error: error.message });
+        }
+    }
+
+    async delete(req: Request, res: Response): Promise<void> {
+        try {
+            const { id } = req.params;
+            if (!id || typeof id !== 'string') {
+                res.status(400).json({ error: 'Invalid ID' });
+                return;
+            }
+            const result = await this.deleteLeagueUseCase.execute({ id });
+            if (result) {
+                res.status(204).send();
+            } else {
+                res.status(404).json({ error: "League not found" });
+            }
+        } catch (error: any) {
+            res.status(500).json({ error: error.message });
+        }
+    }
+}

--- a/src/soccerData/infrastructure/repositories/in-memory-league.ts
+++ b/src/soccerData/infrastructure/repositories/in-memory-league.ts
@@ -1,0 +1,57 @@
+import { League, LeagueCategory } from "../../domain/entities/league.entity.js";
+import { LeagueRepository } from "../../domain/repositories/league.domain.repository.js";
+
+export class InMemoryLeagueRepository implements LeagueRepository {
+    private leagues: League[] = [];
+
+    // Create a new league
+    async create(league: League): Promise<League> {
+        this.leagues.push(league);
+        return league;
+    }
+
+    // Update a league
+    async update(id: string, league: League): Promise<League | null> {
+        const index = this.leagues.findIndex(l => l.id === id);
+        if (index !== -1) {
+            this.leagues[index] = league;
+            return league;
+        }
+        return null;
+    }
+
+    // Delete a league
+    async delete(id: string): Promise<boolean> {
+        const index = this.leagues.findIndex(l => l.id === id);
+        if (index === -1) {
+            return false;
+        }
+        this.leagues.splice(index, 1);
+        return true;
+    }
+
+    // Get all leagues
+    async getAll(): Promise<League[]> {
+        return [...this.leagues];
+    }
+
+    // Get league by id
+    async getById(id: string): Promise<League | null> {
+        return this.leagues.find(l => l.id === id) || null;
+    }
+
+    // Get league by name
+    async getByName(name: string): Promise<League | null> {
+        return this.leagues.find(l => l.name.toLowerCase() === name.toLowerCase()) || null;
+    }
+
+    // Get leagues by country
+    async getByCountry(countryId: string): Promise<League[]> {
+        return this.leagues.filter(l => l.country.id === countryId);
+    }
+
+    // Get leagues by category
+    async getByCategory(category: LeagueCategory): Promise<League[]> {
+        return this.leagues.filter(l => l.category === category);
+    }
+}

--- a/src/soccerData/infrastructure/routes/league.routes.ts
+++ b/src/soccerData/infrastructure/routes/league.routes.ts
@@ -1,0 +1,51 @@
+// Express
+import { Router } from "express";
+
+// Controller
+import { LeagueController } from "../controllers/league.controller.js";
+
+// Use Cases
+import { CreateLeagueUseCase } from "../../application/use-cases/league/create.use-case.js";
+import { GetAllLeagueUseCase } from "../../application/use-cases/league/get-all.use-case.js";
+import { GetLeagueByIdUseCase } from "../../application/use-cases/league/get-by-id.use-case.js";
+import { GetLeagueByNameUseCase } from "../../application/use-cases/league/get-by-name.use-case.js";
+import { GetLeagueByCountryUseCase } from "../../application/use-cases/league/get-by-country.use-case.js";
+import { GetLeagueByCategoryUseCase } from "../../application/use-cases/league/get-by-category.use-case.js";
+import { UpdateLeagueUseCase } from "../../application/use-cases/league/update.use-case.js";
+import { DeleteLeagueUseCase } from "../../application/use-cases/league/delete.use-case.js";
+import { idGenerator, leagueRepository } from "../container.js";
+
+const router = Router();
+
+// Dependency Injection (Manual)
+const createLeagueUseCase = new CreateLeagueUseCase(leagueRepository, idGenerator);
+const getAllLeagueUseCase = new GetAllLeagueUseCase(leagueRepository);
+const getLeagueByIdUseCase = new GetLeagueByIdUseCase(leagueRepository);
+const getLeagueByNameUseCase = new GetLeagueByNameUseCase(leagueRepository);
+const getLeagueByCountryUseCase = new GetLeagueByCountryUseCase(leagueRepository);
+const getLeagueByCategoryUseCase = new GetLeagueByCategoryUseCase(leagueRepository);
+const updateLeagueUseCase = new UpdateLeagueUseCase(leagueRepository);
+const deleteLeagueUseCase = new DeleteLeagueUseCase(leagueRepository);
+
+const leagueController = new LeagueController(
+    createLeagueUseCase,
+    getAllLeagueUseCase,
+    getLeagueByIdUseCase,
+    getLeagueByNameUseCase,
+    getLeagueByCountryUseCase,
+    getLeagueByCategoryUseCase,
+    updateLeagueUseCase,
+    deleteLeagueUseCase
+);
+
+// Routes
+router.post("/", leagueController.create);
+router.get("/", leagueController.getAll);
+router.get("/id/:id", leagueController.getById);
+router.get("/name/:name", leagueController.getByName);
+router.get("/country/:countryId", leagueController.getByCountry);
+router.get("/category/:category", leagueController.getByCategory);
+router.patch("/:id", leagueController.update);
+router.delete("/:id", leagueController.delete);
+
+export { router as leagueRouter }


### PR DESCRIPTION
Implements the domain and infrastructure layers for the League entity. Adds API routes for League CRUD operations. Updates the Express server to include the new routes. Associated with issue #10. Closes #10.